### PR TITLE
Add chained random-discourse die behavior (in-content die for random-triggered pages)

### DIFF
--- a/src/components/Discourse.js
+++ b/src/components/Discourse.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from "react";
+import React, {useState, useEffect, useMemo, useRef} from "react";
 import TextSelector from 'text-selection-react'
 import bookList from '../assets/bookList'
 import BurgerMenu from './svg/BurgerMenu'
@@ -26,6 +26,31 @@ export default function Discourse({discourseName}) {
   const [quotes, setquotes] = useState([])
   const [isStarred, setisStarred] = useState()
   const [htmlData, sethtmlData] = useState()
+  const [isRandomChainActive, setIsRandomChainActive] = useState(false)
+  const [isCurrentPageRandomTriggered, setIsCurrentPageRandomTriggered] = useState(false)
+  const [randomFilterIndices, setRandomFilterIndices] = useState(null)
+  const pendingNavigationSource = useRef("normal")
+
+  const defaultRandomFilterIndices = useMemo(() => {
+    if (!discourseName) {
+      return bookList.map((_, index) => index)
+    }
+    if (Array.isArray(discourseName)) {
+      const validIndices = discourseName
+        .map(name => bookList.indexOf(name))
+        .filter(index => index !== -1)
+      return validIndices.length > 0 ? validIndices : bookList.map((_, index) => index)
+    }
+    if (typeof discourseName === "string") {
+      const lowerFilter = discourseName.toLowerCase()
+      const filteredIndices = bookList
+        .map((name, index) => ({name, index}))
+        .filter(item => item.name.toLowerCase().includes(lowerFilter))
+        .map(item => item.index)
+      return filteredIndices.length > 0 ? filteredIndices : bookList.map((_, index) => index)
+    }
+    return bookList.map((_, index) => index)
+  }, [discourseName])
 
   useEffect(() => {
     if (localStorage.getItem("lastPage") && localStorage.getItem("lastPage") !== undefined) {
@@ -139,8 +164,7 @@ export default function Discourse({discourseName}) {
     if (currentPage<bookList.length-1){
       var integer = parseInt(currentPage, 10);
       let newPageNumber = integer + 1
-      localStorage.setItem('lastPage', newPageNumber);
-      setcurrentPage(newPageNumber)
+      navigateToPage(newPageNumber, "normal")
     }
   }
 
@@ -151,7 +175,7 @@ export default function Discourse({discourseName}) {
         let lastPage = history[history.length-2]
         history.pop()
         localStorage.setItem('history', JSON.stringify(history));
-        setcurrentPage(lastPage)
+        navigateToPage(lastPage, "normal")
       }
     }
   }
@@ -168,15 +192,13 @@ export default function Discourse({discourseName}) {
   }
 
   const handleClickLink = (index) => {
-    setcurrentPage(index)
-    localStorage.setItem('lastPage', index);
+    navigateToPage(index, "normal")
     setStarredStatus()
   }
 
   const handleClickLinkFav = (name) => {
     let index = bookList.indexOf(name)
-    setcurrentPage(index)
-    localStorage.setItem('lastPage', index);
+    navigateToPage(index, "normal")
     setStarredStatus()
   }
 
@@ -214,6 +236,48 @@ export default function Discourse({discourseName}) {
     }
   }
 
+  const navigateToPage = (index, source = "normal") => {
+    pendingNavigationSource.current = source
+    localStorage.setItem('lastPage', index)
+    setcurrentPage(index)
+  }
+
+  const getRandomIndexFromFilter = (filterIndices) => {
+    if (!filterIndices || filterIndices.length === 0) {
+      return null
+    }
+    if (filterIndices.length === 1) {
+      return filterIndices[0]
+    }
+    const choices = filterIndices.filter(index => index !== currentPage)
+    const pool = choices.length > 0 ? choices : filterIndices
+    return pool[Math.floor(Math.random() * pool.length)]
+  }
+
+  const handleClickRandomDiscourse = () => {
+    const activeFilter = randomFilterIndices && randomFilterIndices.length > 0
+      ? randomFilterIndices
+      : defaultRandomFilterIndices
+    const randomIndex = getRandomIndexFromFilter(activeFilter)
+    if (randomIndex == null) {
+      return
+    }
+    setRandomFilterIndices(activeFilter)
+    setIsRandomChainActive(true)
+    navigateToPage(randomIndex, "random")
+  }
+
+  useEffect(() => {
+    if (pendingNavigationSource.current === "random") {
+      setIsCurrentPageRandomTriggered(true)
+    } else {
+      setIsCurrentPageRandomTriggered(false)
+      setIsRandomChainActive(false)
+      setRandomFilterIndices(null)
+    }
+    pendingNavigationSource.current = "normal"
+  }, [currentPage])
+
   return (
     <div>
 
@@ -233,6 +297,13 @@ export default function Discourse({discourseName}) {
       </div>
 
       <div className={discourse.theDiscourse} dangerouslySetInnerHTML={{__html: htmlData}}></div>
+      {isRandomChainActive && isCurrentPageRandomTriggered && (
+        <div className={discourse.randomDiscourseButtonWrapper}>
+          <button className={discourse.randomDiscourseButton} onClick={handleClickRandomDiscourse}>
+            <span role="img" aria-label="random discourse">🎲</span>
+          </button>
+        </div>
+      )}
 
       {/* quotes */}
       <div className={displayQuotes?q.quotesWrapper:q.isHidden}>
@@ -300,6 +371,12 @@ export default function Discourse({discourseName}) {
           <div>
             <button className={menu.nextButton} onClick={handleClickNext}><ArrowNext></ArrowNext></button>
             <h6 className={menu.menuTitles}>next</h6>
+          </div>
+          <div>
+            <button className={menu.randomButton} onClick={handleClickRandomDiscourse}>
+              <span role="img" aria-label="random discourse">🎲</span>
+            </button>
+            <h6 className={menu.menuTitles}>random</h6>
           </div>
         </div>
       </div>

--- a/src/components/discourse.module.css
+++ b/src/components/discourse.module.css
@@ -6,10 +6,26 @@
     overflow-wrap: break-word;
 }
 
+.randomDiscourseButtonWrapper {
+    position: fixed;
+    right: 18px;
+    bottom: 94px;
+    z-index: 5;
+}
+
+.randomDiscourseButton {
+    font-size: 1.2rem;
+    padding: 0.3rem 0.6rem;
+}
+
 @media only screen and (max-width: 600px) {
     .theDiscourse {
         color: rgb(22, 22, 22);
         font-size: 1.3rem;
         padding: 5vh;
+    }
+
+    .randomDiscourseButtonWrapper {
+        bottom: 104px;
     }
   }


### PR DESCRIPTION
### Motivation

- Provide a way to start a random discourse from the menu and then let discourses that were reached via that random trigger keep a die button so the user can continue getting random discourses that respect the original filter.

### Description

- Added random-chain state and navigation source tracking in `src/components/Discourse.js` (`isRandomChainActive`, `isCurrentPageRandomTriggered`, `randomFilterIndices`, `pendingNavigationSource`) to distinguish random-triggered navigation from normal navigation.
- Introduced `defaultRandomFilterIndices` (derived from the `discourseName` prop) and `getRandomIndexFromFilter` plus `handleClickRandomDiscourse` to resolve and reuse the initial filter across a random chain.
- Centralized navigation through `navigateToPage(index, source)` and updated normal navigation paths (`next`, `back`, list/favorite clicks, links) to reset random-chain behavior when the source is non-random.
- Render an in-content die button that appears only when the current page was reached via the random die, and added a menu die button to start the random chain; added styling in `src/components/discourse.module.css` for the in-content die (desktop and mobile positions).

### Testing

- Built the app to verify integration with `NODE_OPTIONS=--openssl-legacy-provider npm run build`, which completed successfully with warnings.
- A plain `npm run build` failed in this environment due to Node/OpenSSL compatibility (`ERR_OSSL_EVP_UNSUPPORTED`) that is unrelated to the feature changes.
- The build output showed only existing lint warnings but no feature errors after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e32e45108320927370c68070fe08)